### PR TITLE
Allows compilation on tvOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ let package = Package(
     name: "CombineDataSources",
     platforms: [
       .iOS(.v13),
+      .tvOS(.v13),
     ],
     products: [
         .library(


### PR DESCRIPTION
Adds tvOS as platform for SwiftUI. Otherwise compilation of our tvOS app failed.