### PR TITLE
Fixes wrong index path occuring after performBatchUpdates

### DIFF
--- a/Sources/CombineDataSources/CollectionView/CollectionViewItemsController.swift
+++ b/Sources/CombineDataSources/CollectionView/CollectionViewItemsController.swift
@@ -84,7 +84,9 @@ public class CollectionViewItemsController<CollectionType>: NSObject, UICollecti
         }
       }
       collection = items
-    }, completion: nil)
+    }, completion: { [weak self] _ in
+      self?.collectionView.reloadData()
+    })
   }
   
   // MARK: - UITableViewDataSource protocol


### PR DESCRIPTION
When performing large amounts of updates to collectionView, there is a bug that cellForRowAt contains incorrect indexPath. I found out that it's most likely caused by an issue in performBatchUpdates function which sometimes causes collectionView to have outdated results. 